### PR TITLE
1564 Allow activities to be cancelled without logging an error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.widewail</groupId>
     <artifactId>spring-stepfunction-client</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <name>Spring Step Functions Client</name>
 
     <parent>

--- a/src/main/java/com/widewail/spring/stepfunctions/ActivityResult.java
+++ b/src/main/java/com/widewail/spring/stepfunctions/ActivityResult.java
@@ -13,15 +13,36 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class ActivityResult<T> {
     public enum ActivityResultOutcome {
-        SUCCESS, FAIL, HEARTBEAT
+        SUCCESS, FAIL, CANCEL, HEARTBEAT
     }
 
     private final T payload;
     private final String failureReason;
     private final ActivityResultOutcome outcome;
 
+    /**
+     * Return an activity result representing an error. This method is intended
+     * to report unexpected failure modes which may require engineering effort to
+     * correct.
+     * @param reason the error message
+     * @return an activity result representing an error
+     * @see #cancel(String) Use cancel to cancel execution without logging an
+     * error.
+     */
     public static <T> ActivityResult<T> fail(String reason) {
         return new ActivityResult<>(null, reason, ActivityResultOutcome.FAIL);
+    }
+
+    /**
+     * Return an activity result representing a non-error cancellation. This
+     * method is intended to report failure modes which are expected to
+     * occur, such as operator error.
+     * @param reason the error message
+     * @return an activity result representing a non-error cancellation condition
+     * @see #fail(String) Use fail for error conditions.
+     */
+    public static <T> ActivityResult<T> cancel(String reason) {
+        return new ActivityResult<>(null, reason, ActivityResultOutcome.CANCEL);
     }
 
     public static <T> ActivityResult<T> success(T payload) {


### PR DESCRIPTION
## Author Checklist

- [❌] I validated this in QA or have noted below why it cannot

This is a non-functional update to library code, so there isn't really a good way to UAT it. It'll be naturally tested as part of the larger work around 1564.

## Release Notes

- [❌] Includes a migration

## Reviewer Checklist

- [ ] Follows [best practices](https://github.com/Widewail/engineering-docs/wiki/BestPractices)
- [ ] No large transaction boundaries
- [ ] Queued messages published outside of transactions (if applicable)
- [ ] API calls happen outside of transactions (if applicable)
